### PR TITLE
Override offsets retention minutes config

### DIFF
--- a/go-kafka.go
+++ b/go-kafka.go
@@ -44,6 +44,7 @@ func init() {
 	Config.Group.Return.Notifications = true
 	Config.Consumer.Return.Errors = true
 	Config.Consumer.Offsets.Initial = sarama.OffsetOldest
+	Config.Consumer.Offsets.Retention = 192 * time.Hour // 8 days to be above the default message retention time (7 days)
 	Config.Producer.Timeout = 5 * time.Second
 	Config.Producer.Retry.Max = 3
 	Config.Producer.Return.Successes = true


### PR DESCRIPTION
Default `offsets.retention.minutes` is set to 1440 so 1 day.
But the default message retention time is 7 days.
We chose to apply a default value of 8 days for the offset retention in order to avoid reparsing twice the same message