### PR TITLE
Handle error topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ errc <- listener.Listen(ctx)
 * Create a producer
 * Create a go-kit like server
 
+## Consumer error handling
+
+The listener object is able to have a specific handle for consuming errors.
+By default, if an error occurs, it's retried 3 times (each attempt is separated by 2 seconds).
+And if there's still an error after the 3 retries, the error is logged and pushed to a topic named like `"group-id"-"original-topic-name"-error`.
+
+All this strategy can be overridden through the following config variables:
+
+* ConsumerMaxRetries
+* DurationBeforeRetry
+* PushConsumerErrorsToTopic
+* ErrorTopicPattern
+
 ## License
 
 go-kafka is licensed under the MIT license. (http://opensource.org/licenses/MIT)

--- a/go-kafka.go
+++ b/go-kafka.go
@@ -36,6 +36,15 @@ var ConsumerMaxRetries = 3
 // By default 2 seconds.
 var DurationBeforeRetry = 2 * time.Second
 
+// PushConsumerErrorsToTopic is a boolean to define if messages in error have to be pushed to an error topic.
+var PushConsumerErrorsToTopic = true
+
+// ErrorTopicPattern is the error topic name pattern.
+// By default "consumergroup-topicname-error"
+// Use $$CG$$ as consumer group placeholder
+// Use $$T$$ as original topic name placeholder
+var ErrorTopicPattern = "$$CG$$-$$T$$-error"
+
 // Config is the sarama (cluster) config used for the consumer and producer.
 var Config = cluster.NewConfig()
 

--- a/producer.go
+++ b/producer.go
@@ -30,6 +30,20 @@ func NewProducer(brokers []string) (Producer, error) {
 	return producer{p}, nil
 }
 
+// newProducerFromClient creates a new instance of Producer from an existing client
+func newProducerFromClient(client sarama.Client) (Producer, error) {
+	if client == nil {
+		return nil, errors.New("cannot create new producer from client, client cannot be nil")
+	}
+
+	p, err := sarama.NewSyncProducerFromClient(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return producer{p}, nil
+}
+
 // SendMessage is used to send the meassage to kafka
 func (p producer) SendMessage(key []byte, msg []byte, topic string) (partition int32, offset int64, err error) {
 	if p.syncProducer == nil {


### PR DESCRIPTION
Today, when consumming a message is failing, we have a retry policy.
It retries 3 times, and if there's still an error, it's logged and offset is marked.

In order to have more persistent and queryable data, we chose to develop a logic to be able to push "bad" handled messages into a dedicated topic.
By default this topic is named `"consumer-group name"-"original topic name"-error`.

It can be overriden with the config variable `ErrorTopicPattern`.
Moreover, this feature is enabled by default but can be set to false by setting variable `PushConsumerErrorsToTopic`