### PR TITLE
Add SASL authentication

### DIFF
--- a/go-kafka.go
+++ b/go-kafka.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	"github.com/bsm/sarama-cluster"
+	cluster "github.com/bsm/sarama-cluster"
 )
 
 // StdLogger is used to log messages.
@@ -58,4 +58,11 @@ func init() {
 	Config.Producer.Retry.Max = 3
 	Config.Producer.Return.Successes = true
 	Config.Producer.RequiredAcks = sarama.WaitForAll
+	if os.Getenv("KAFKA_SASL_AUTH_ENABLED") == "true" {
+		Config.Net.TLS.Enable = true
+		Config.Net.SASL.Enable = true
+		Config.Net.SASL.Handshake = true
+		Config.Net.SASL.User = os.Getenv("KAFKA_SASL_USER")
+		Config.Net.SASL.Password = os.Getenv("KAFKA_SASL_PASSWORD")
+	}
 }


### PR DESCRIPTION
Add the possibility to use the SASL authentication to connect to a kafka
cluster.

By default, the SASL authentication is not enabled, the environment
variable `KAFKA_SASL_AUTH_ENABLED` need to be set to `true` and the
`KAFKA_SASL_USER` and `KAFKA_SASL_PASSWORD` need to be set with the
correct user/password.

SASL authentication is required to connect to the Confluent Cloud
clusters.