### PR TITLE
add default murmur2 hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+
+# ignore IDE
+.idea

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ All this strategy can be overridden through the following config variables:
 * PushConsumerErrorsToTopic
 * ErrorTopicPattern
 
+## Default configuration
+
+Configuration of consumer/producer is opinionated. It aim to resolve simply problems that have taken us by surprise in the past.
+For this reason:
+- the default partioner is based on murmur2 instead of the one sarama use by default
+- offset retention is set to 8 days
+- initial offset is oldest
+
 ## License
 
 go-kafka is licensed under the MIT license. (http://opensource.org/licenses/MIT)

--- a/go-kafka.go
+++ b/go-kafka.go
@@ -58,4 +58,5 @@ func init() {
 	Config.Producer.Retry.Max = 3
 	Config.Producer.Return.Successes = true
 	Config.Producer.RequiredAcks = sarama.WaitForAll
+	Config.Producer.Partitioner = NewJVMCompatiblePartitioner
 }

--- a/murmur.go
+++ b/murmur.go
@@ -1,3 +1,26 @@
+/*MIT License
+
+Copyright (c) 2019 Alexandr Burdiyan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 // from https://github.com/burdiyan/kafkautil/blob/master/partitioner.go
 // copied here to ensure this stay.
 package kafka

--- a/murmur.go
+++ b/murmur.go
@@ -1,0 +1,98 @@
+package kafka
+
+import (
+	"hash"
+
+	"github.com/Shopify/sarama"
+)
+
+// NewJVMCompatiblePartitioner creates a Sarama partitioner that uses
+// the same hashing algorithm as JVM Kafka clients.
+func NewJVMCompatiblePartitioner(topic string) sarama.Partitioner {
+	return sarama.NewCustomHashPartitioner(MurmurHasher)(topic)
+}
+
+// murmurHash implements hash.Hash32 interface,
+// solely to conform to required hasher for Sarama.
+// it does not support streaming since it is not required for Sarama.
+type murmurHash struct {
+	v int32
+}
+
+// MurmurHasher creates murmur2 hasher implementing hash.Hash32 interface.
+// The implementation is not full and does not support streaming.
+// It only implements the interface to comply with sarama.NewCustomHashPartitioner signature.
+// But Sarama only uses Write method once, when writing keys and values of the message,
+// so streaming support is not necessary.
+func MurmurHasher() hash.Hash32 {
+	return new(murmurHash)
+}
+
+func (m *murmurHash) Write(d []byte) (n int, err error) {
+	n = len(d)
+	m.v = murmur2(d)
+	return
+}
+
+func (m *murmurHash) Reset() {
+	m.v = 0
+}
+
+func (m *murmurHash) Size() int { return 32 }
+
+func (m *murmurHash) BlockSize() int { return 4 }
+
+// Sum is noop.
+func (m *murmurHash) Sum(in []byte) []byte {
+	return in
+}
+
+func (m *murmurHash) Sum32() uint32 {
+	return uint32(toPositive(m.v))
+}
+
+// murmur2 implements hashing algorithm used by JVM clients for Kafka.
+// See the original implementation: https://github.com/apache/kafka/blob/1.0.0/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L353
+func murmur2(data []byte) int32 {
+	length := int32(len(data))
+	seed := uint32(0x9747b28c)
+	m := int32(0x5bd1e995)
+	r := uint32(24)
+
+	h := int32(seed ^ uint32(length))
+	length4 := length / 4
+
+	for i := int32(0); i < length4; i++ {
+		i4 := i * 4
+		k := int32(data[i4+0]&0xff) + (int32(data[i4+1]&0xff) << 8) + (int32(data[i4+2]&0xff) << 16) + (int32(data[i4+3]&0xff) << 24)
+		k *= m
+		k ^= int32(uint32(k) >> r)
+		k *= m
+		h *= m
+		h ^= k
+	}
+
+	switch length % 4 {
+	case 3:
+		h ^= int32(data[(length & ^3)+2]&0xff) << 16
+		fallthrough
+	case 2:
+		h ^= int32(data[(length & ^3)+1]&0xff) << 8
+		fallthrough
+	case 1:
+		h ^= int32(data[length & ^3] & 0xff)
+		h *= m
+	}
+
+	h ^= int32(uint32(h) >> 13)
+	h *= m
+	h ^= int32(uint32(h) >> 15)
+
+	return h
+}
+
+// toPositive converts i to positive number as per the original implementation in the JVM clients for Kafka.
+// See the original implementation: https://github.com/apache/kafka/blob/1.0.0/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L741
+func toPositive(i int32) int32 {
+	return i & 0x7fffffff
+}

--- a/murmur.go
+++ b/murmur.go
@@ -1,3 +1,5 @@
+// from https://github.com/burdiyan/kafkautil/blob/master/partitioner.go
+// copied here to ensure this stay.
 package kafka
 
 import (

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -1,0 +1,67 @@
+/*MIT License
+
+Copyright (c) 2019 Alexandr Burdiyan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// from https://github.com/burdiyan/kafkautil/blob/master/partitioner.go
+// copied here to ensure this stay.
+
+package kafka
+
+import (
+	"testing"
+)
+
+func TestHashInterface(t *testing.T) {
+	var _ = MurmurHasher()
+}
+
+func TestMurmur2(t *testing.T) {
+	// Test cases are generated offline using JVM Kafka client for version 1.0.0.
+	cases := []struct {
+		Input            []byte
+		Expected         int32
+		ExpectedPositive uint32
+	}{
+		{[]byte("21"), -973932308, 1173551340},
+		{[]byte("foobar"), -790332482, 1357151166},
+		{[]byte{12, 42, 56, 24, 109, 111}, 274204207, 274204207},
+		{[]byte("a-little-bit-long-string"), -985981536, 1161502112},
+		{[]byte("a-little-bit-longer-string"), -1486304829, 661178819},
+		{[]byte("lkjh234lh9fiuh90y23oiuhsafujhadof229phr9h19h89h8"), -58897971, 2088585677},
+		{[]byte{'a', 'b', 'c'}, 479470107, 479470107},
+	}
+
+	hasher := MurmurHasher()
+
+	for _, c := range cases {
+		if res := murmur2(c.Input); res != c.Expected {
+			t.Errorf("for %q expected: %d, got: %d", c.Input, c.Expected, res)
+		}
+
+		hasher.Reset()
+		hasher.Write(c.Input)
+
+		if res2 := hasher.Sum32(); res2 != uint32(c.ExpectedPositive) {
+			t.Errorf("hasher: for %q expected: %d, got: %d", c.Input, c.ExpectedPositive, res2)
+		}
+	}
+}


### PR DESCRIPTION
Currently the murmur2 code is copy pasted on every application that need it. So basically every consumer/producer.  Once you go with one hasher, you don't go back!

So let's put this file here, it will make thing look cleaner. Also it enable us to setup the config the way we expect it to be for any producer using this partioner.
