### PR TITLE
Allow instrumenting several listener(s)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.10.x"
+  - "1.12.x"
 
 notifications:
  email: false
@@ -10,7 +10,7 @@ before_install:
  - go get github.com/mattn/goveralls
 
 script:
- - go get -t ./...
+ - go get -t -u ./...
  - make build
  - make test
  - $GOPATH/bin/goveralls -service=travis-ci

--- a/instrumenting.go
+++ b/instrumenting.go
@@ -3,40 +3,85 @@ package kafka
 import (
 	"context"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+var (
+	request      *prometheus.CounterVec
+	latency      *prometheus.SummaryVec
+	requestMutex = &sync.Mutex{}
+	latencyMutex = &sync.Mutex{}
+	metricLabels = []string{"kafka_topic", "success", "group_id"}
+)
+
+type prometheusSummaryVec interface {
+	WithLabelValues(lvs ...string) prometheus.Observer
+}
+
+type prometheusCounterVec interface {
+	WithLabelValues(lvs ...string) prometheus.Counter
+}
+
 // ConsumerMetricsService object represents consumer metrics
 type ConsumerMetricsService struct {
-	request *prometheus.CounterVec
-	latency *prometheus.SummaryVec
+	request prometheusCounterVec
+	latency prometheusSummaryVec
+	groupID string
+}
+
+func getPrometheusRequestInstrumentation() prometheusCounterVec {
+	if request != nil {
+		return request
+	}
+
+	requestMutex.Lock()
+	defer requestMutex.Unlock()
+	if request == nil {
+		request = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "kafka",
+				Subsystem: "consumer",
+				Name:      "requests_total",
+				Help:      "Number of requests processed",
+			}, metricLabels)
+		prometheus.MustRegister(request)
+	}
+
+	return request
+}
+
+func getPrometheusLatencyInstrumentation() prometheusSummaryVec {
+	if latency != nil {
+		return latency
+	}
+
+	latencyMutex.Lock()
+	defer latencyMutex.Unlock()
+	if latency == nil {
+		latency = prometheus.NewSummaryVec(
+			prometheus.SummaryOpts{
+				Namespace: "kafka",
+				Subsystem: "consumer",
+				Name:      "requests_latency_milliseconds",
+				Help:      "Total duration in milliseconds",
+			}, metricLabels)
+		prometheus.MustRegister(latency)
+	}
+
+	return latency
 }
 
 // NewConsumerMetricsService creates a layer of service that add metrics capability
-func NewConsumerMetricsService(appName string) *ConsumerMetricsService {
+func NewConsumerMetricsService(groupID string) *ConsumerMetricsService {
 	var c ConsumerMetricsService
-	fieldKeys := []string{"kafka_topic", "success"}
+	c.groupID = groupID
 
-	c.request = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "kafka",
-			Subsystem: "consumer",
-			Name:      "requests_total",
-			Help:      "Number of requests processed",
-		}, fieldKeys)
-	prometheus.MustRegister(c.request)
-
-	c.latency = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Namespace: "kafka",
-			Subsystem: "consumer",
-			Name:      "requests_latency_milliseconds",
-			Help:      "Total duration in milliseconds",
-		}, []string{"kafka_topic"})
-	prometheus.MustRegister(c.latency)
+	c.request = getPrometheusRequestInstrumentation()
+	c.latency = getPrometheusLatencyInstrumentation()
 
 	return &c
 }
@@ -46,12 +91,9 @@ func (c *ConsumerMetricsService) Instrumentation(next Handler) Handler {
 	return func(ctx context.Context, msg *sarama.ConsumerMessage) (err error) {
 		// add metrics to this method
 		defer func(begin time.Time) {
-			var success bool
-			if err == nil {
-				success = true
-			}
-			c.latency.WithLabelValues(msg.Topic).Observe(time.Since(begin).Seconds() * 1e3)
-			c.request.WithLabelValues(msg.Topic, strconv.FormatBool(success)).Inc()
+			success := strconv.FormatBool(err == nil)
+			c.latency.WithLabelValues(msg.Topic, success, c.groupID).Observe(time.Since(begin).Seconds() * 1e3)
+			c.request.WithLabelValues(msg.Topic, success, c.groupID).Inc()
 		}(time.Now())
 
 		err = next(ctx, msg)

--- a/instrumenting_test.go
+++ b/instrumenting_test.go
@@ -23,3 +23,14 @@ func Test_NewConsumerMetricsService_Should_Return_Success_When_Success(t *testin
 	// Assert
 	assert.Nil(t, err)
 }
+
+func Test_NewConsumerMetricsService_Should_Allow_Multiple_Instance(t *testing.T) {
+	// Arrange
+	group1 := "test_ok"
+	group2 := "test_ok_other"
+	s1 := NewConsumerMetricsService(group1)
+	s2 := NewConsumerMetricsService(group2)
+
+	assert.Equal(t, group1, s1.groupID)
+	assert.Equal(t, group2, s2.groupID)
+}

--- a/listener_test.go
+++ b/listener_test.go
@@ -108,7 +108,7 @@ func Test_NewListener_Happy_Path(t *testing.T) {
 
 	metadataResponse := new(sarama.MetadataResponse)
 	metadataResponse.AddBroker(leaderBroker.Addr(), leaderBroker.BrokerID())
-	metadataResponse.AddTopicPartition("topic-test", 0, leaderBroker.BrokerID(), nil, nil, sarama.ErrNoError)
+	metadataResponse.AddTopicPartition("topic-test", 0, leaderBroker.BrokerID(), nil, nil, nil, sarama.ErrNoError)
 	leaderBroker.Returns(metadataResponse)
 
 	consumerMetadataResponse := sarama.ConsumerMetadataResponse{

--- a/murmur.go
+++ b/murmur.go
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-// from https://github.com/burdiyan/kafkautil/blob/master/partitioner.go
+// Package kafka copied from https://github.com/burdiyan/kafkautil/blob/master/partitioner.go
 // copied here to ensure this stay.
 package kafka
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -102,7 +102,7 @@ func Test_NewProducer_Return_Working_Producer(t *testing.T) {
 
 	metadataResponse := new(sarama.MetadataResponse)
 	metadataResponse.AddBroker(leaderBroker.Addr(), leaderBroker.BrokerID())
-	metadataResponse.AddTopicPartition("topic-test", 0, leaderBroker.BrokerID(), nil, nil, sarama.ErrNoError)
+	metadataResponse.AddTopicPartition("topic-test", 0, leaderBroker.BrokerID(), nil, nil, nil, sarama.ErrNoError)
 	leaderBroker.Returns(metadataResponse)
 
 	prodSuccess := new(sarama.ProduceResponse)
@@ -121,7 +121,7 @@ func Test_newProducerFromClient_Return_Working_Producer(t *testing.T) {
 
 	metadataResponse := new(sarama.MetadataResponse)
 	metadataResponse.AddBroker(leaderBroker.Addr(), leaderBroker.BrokerID())
-	metadataResponse.AddTopicPartition("topic-test", 0, leaderBroker.BrokerID(), nil, nil, sarama.ErrNoError)
+	metadataResponse.AddTopicPartition("topic-test", 0, leaderBroker.BrokerID(), nil, nil, nil, sarama.ErrNoError)
 	leaderBroker.Returns(metadataResponse)
 
 	prodSuccess := new(sarama.ProduceResponse)


### PR DESCRIPTION
In order to allow several listeners to be
instrumented we needed to initiate the prometheus
counter once and only once

We choose to use [double checked locking](https://en.wikipedia.org/wiki/Double-checked_locking)

We also took this opportunity to
expose `group_id` label to ensure
metrics are properly defined