### PR TITLE
add metrics for number of messages dropped

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -188,7 +188,9 @@ func (l *listener) handleErrorMessage(ctx context.Context, initialError error, m
 	ErrorLogger.Printf("Consume: %+v", initialError)
 
 	// Inc dropped messages metrics
-	l.instrumenting.droppedRequest.WithLabelValues("kafka_topic", msg.Topic, "group_id", l.groupID).Inc()
+	if l.instrumenting != nil && l.instrumenting.droppedRequest != nil {
+		l.instrumenting.droppedRequest.WithLabelValues("kafka_topic", msg.Topic, "group_id", l.groupID).Inc()
+	}
 
 	// publish to dead queue if requested in config
 	if PushConsumerErrorsToTopic {

--- a/listener.go
+++ b/listener.go
@@ -184,8 +184,13 @@ func handleMessageWithRetry(ctx context.Context, handler Handler, msg *sarama.Co
 }
 
 func (l *listener) handleErrorMessage(ctx context.Context, initialError error, msg *sarama.ConsumerMessage) {
+	// Log
 	ErrorLogger.Printf("Consume: %+v", initialError)
 
+	// Inc dropped messages metrics
+	l.instrumenting.droppedRequest.WithLabelValues("kafka_topic", msg.Topic, "group_id", l.groupID).Inc()
+
+	// publish to dead queue if requested in config
 	if PushConsumerErrorsToTopic {
 		if l.producer == nil {
 			ErrorLogger.Printf("Cannot send message to error topic: producer is nil")


### PR DESCRIPTION
The current metric `requests_total` does not allow the make a good alert on the number of messages failed.

The retry logic make some request appear in `requests_total` with success `false` even if they might succeed later.

We need to have access to the info ''how many request definitely failed' to make a good alert.

I could have added a label to `requests_total`. Something like `retry_count` or `definitive_failure`(true/false).
However i thought this would just make the metric less understandable and heavier for prometheus.

So i opted for the most basic change, a new metric.