### PR TITLE
add Tracing with context extracted from kafka message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - go get github.com/mattn/goveralls
 
 script:
-  - dep ensure
+  - make install
   - make build
   - make test
   - $GOPATH/bin/goveralls -service=travis-ci -ignore "mocks/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ go:
   - "1.12.x"
 
 notifications:
- email: false
+  email: false
 
 before_install:
- - go get github.com/mattn/goveralls
+  - go get github.com/mattn/goveralls
 
 script:
   - dep ensure
- - make build
- - make test
- - $GOPATH/bin/goveralls -service=travis-ci -ignore "mocks/*"
+  - make build
+  - make test
+  - $GOPATH/bin/goveralls -service=travis-ci -ignore "mocks/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
  - go get github.com/mattn/goveralls
 
 script:
- - go get -t -u ./...
+  - dep ensure
  - make build
  - make test
  - $GOPATH/bin/goveralls -service=travis-ci -ignore "mocks/*"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v1.23.0"
 
 [[projects]]
+  digest = "1:e64acfe8cda1955db545ede8e863c54d69f1ac6cd058df4349be4040320840fd"
+  name = "github.com/apache/thrift"
+  packages = ["lib/go/thrift"]
+  pruneopts = "UT"
+  revision = "327ebb6c2b6df8bf075da02ef45a2a034e9b79ba"
+  version = "0.11.0"
+
+[[projects]]
   digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
@@ -66,6 +74,22 @@
   version = "v0.9.0"
 
 [[projects]]
+  digest = "1:4062bc6de62d73e2be342243cf138cf499b34d558876db8d9430e2149388a4d8"
+  name = "github.com/go-logfmt/logfmt"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "07c9b44f60d7ffdfb7d8efe1ad539965737836dc"
+  version = "v0.4.0"
+
+[[projects]]
+  digest = "1:4882ca4e50712f367a52a467a277dcd8ef877b82acaa5973baea92fe7443f2eb"
+  name = "github.com/gogo/protobuf"
+  packages = ["proto"]
+  pruneopts = "UT"
+  revision = "0ca988a254f991240804bf9821f3450d87ccbb1b"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:573ca21d3669500ff845bdebee890eb7fc7f0f50c59f2132f2a0c6b03d85086a"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
@@ -101,12 +125,55 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:a64e323dc06b73892e5bb5d040ced475c4645d456038333883f58934abbf6f72"
+  name = "github.com/kr/logfmt"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
+
+[[projects]]
   digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
   pruneopts = "UT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2da0e5077ed40453dc281b9a2428d84cf6ad14063aed189f6296ca5dd25cf13d"
+  name = "github.com/opentracing-contrib/go-observer"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a52f2342449246d5bcc273e65cbdcfa5f7d6c63c"
+
+[[projects]]
+  digest = "1:11e62d6050198055e6cd87ed57e5d8c669e84f839c16e16f192374d913d1a70d"
+  name = "github.com/opentracing/opentracing-go"
+  packages = [
+    ".",
+    "ext",
+    "log",
+  ]
+  pruneopts = "UT"
+  revision = "659c90643e714681897ec2521c60567dd21da733"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:ccfa433e8af45dd142141e0b19ec3ebbabb7fb3b55dbb30fbf84681020b739c6"
+  name = "github.com/openzipkin/zipkin-go-opentracing"
+  packages = [
+    ".",
+    "flag",
+    "thrift/gen-go/scribe",
+    "thrift/gen-go/zipkincore",
+    "types",
+    "wire",
+  ]
+  pruneopts = "UT"
+  revision = "45e90b00710a4c34a1a7d8a78d90f9b010b0bd4d"
+  version = "v0.3.2"
 
 [[projects]]
   digest = "1:f690a0a27cefae695fa9587aa3ed23652e593be1d98b35f8184d10bccec30444"
@@ -186,6 +253,14 @@
   revision = "9beb055b7962d16947a14e1cd718098a2431e20e"
 
 [[projects]]
+  digest = "1:5de72c3e3e02d7366bdb2afc2fdd42e860005482e22a8186ad57677a9f4845df"
+  name = "github.com/ricardo-ch/go-tracing"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f92f91efc2a21332d39c2ea5f85a86fcb1df335b"
+  version = "v0.3.2-1"
+
+[[projects]]
   digest = "1:ac83cf90d08b63ad5f7e020ef480d319ae890c208f8524622a2f3136e2686b02"
   name = "github.com/stretchr/objx"
   packages = ["."]
@@ -217,9 +292,10 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3e0062766e6b0bcfe1ba1ed1d3f08a8e1e99cd5831426e2596dc9537d28f2adb"
+  digest = "1:c3e095ce762c6eb934a2c9d117387970076a0213c009b0ad8e6e9f80fef7475a"
   name = "golang.org/x/net"
   packages = [
+    "context",
     "internal/socks",
     "proxy",
   ]
@@ -306,8 +382,10 @@
   input-imports = [
     "github.com/Shopify/sarama",
     "github.com/go-kit/kit/endpoint",
+    "github.com/opentracing/opentracing-go",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/ricardo-ch/go-tracing",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
   ]

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,8 @@ mocks:
 	go get github.com/vektra/mockery/.../
 	${.MOCKERY_PATH} -case "underscore" -dir vendor/github.com/Shopify/sarama -output ./mocks -case "underscore" -name="(ConsumerGroupHandler)|(SyncProducer)|(ConsumerGroup)|(ConsumerGroupClaim)|(ConsumerGroupSession)"
 	${.MOCKERY_PATH} -case "underscore" -dir ./ -output ./mocks -name=StdLogger
+
+.PHONY: install
+install:
+	go get -u github.com/golang/dep/cmd/dep
+	dep ensure -v

--- a/listener.go
+++ b/listener.go
@@ -24,7 +24,7 @@ type listener struct {
 	handlers      Handlers
 	groupID       string
 	instrumenting *ConsumerMetricsService
-	tracer        ContextFunc
+	tracer        TracingFunc
 }
 
 // listenerContextKey defines the key to provide in context

--- a/listener.go
+++ b/listener.go
@@ -178,8 +178,7 @@ func (l *listener) onNewMessage(msg *sarama.ConsumerMessage, session sarama.Cons
 
 	var span opentracing.Span
 	if l.tracer != nil {
-		span, messageContext = l.
-			tracer(messageContext, msg)
+		span, messageContext = l.tracer(messageContext, msg)
 		defer span.Finish()
 	}
 

--- a/listener.go
+++ b/listener.go
@@ -179,7 +179,9 @@ func (l *listener) onNewMessage(msg *sarama.ConsumerMessage, session sarama.Cons
 	var span opentracing.Span
 	if l.tracer != nil {
 		span, messageContext = l.tracer(messageContext, msg)
-		defer span.Finish()
+		if span != nil {
+			defer span.Finish()
+		}
 	}
 
 	handler := l.handlers[msg.Topic]

--- a/listener.go
+++ b/listener.go
@@ -178,7 +178,8 @@ func (l *listener) onNewMessage(msg *sarama.ConsumerMessage, session sarama.Cons
 
 	var span opentracing.Span
 	if l.tracer != nil {
-		span, messageContext = l.tracer(messageContext)
+		span, messageContext = l.
+			tracer(messageContext, msg)
 		defer span.Finish()
 	}
 

--- a/listener_test.go
+++ b/listener_test.go
@@ -195,7 +195,7 @@ func Test_ConsumeClaim_Message_Error_WithPanicTopic(t *testing.T) {
 }
 
 // Basically a copy paste of the happy path but with tracing
-// This test only check the tracing does not prevent the consumption
+// This test only checks that the tracing is not preventing the consumption
 func Test_ConsumerClaim_HappyPath_WithTracing(t *testing.T) {
 	msgChanel := make(chan *sarama.ConsumerMessage, 1)
 	msgChanel <- &sarama.ConsumerMessage{

--- a/options.go
+++ b/options.go
@@ -15,16 +15,19 @@ func WithInstrumenting() ListenerOption {
 	}
 }
 
-// ContextFunc is used to create tracing and/or propagate the tracing context from the each messages to the go context.
-type ContextFunc func(ctx context.Context, msg *sarama.ConsumerMessage) (opentracing.Span, context.Context)
+// TracingFunc is used to create tracing and/or propagate the tracing context from the each messages to the go context.
+type TracingFunc func(ctx context.Context, msg *sarama.ConsumerMessage) (opentracing.Span, context.Context)
 
-// WithTracing accept a ContextFunc to execute before each message
-func WithTracing(tracer ContextFunc) ListenerOption {
+// WithTracing accept a TracingFunc to execute before each message
+func WithTracing(tracer TracingFunc) ListenerOption {
 	return func(l *listener) {
 		l.tracer = tracer
 	}
 }
 
+// DefaultTracing implement TracingFunc
+// It fetch opentracing headers from the kafka message headers, then create a span using the opentracing.GlobalTracer()
+// usage: `listener, err = kafka.NewListener(brokers, appName, handlers, kafka.WithTracing(kafka.DefaultTracing))`
 func DefaultTracing(ctx context.Context, msg *sarama.ConsumerMessage) (opentracing.Span, context.Context) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/options.go
+++ b/options.go
@@ -26,7 +26,7 @@ func WithTracing(tracer TracingFunc) ListenerOption {
 }
 
 // DefaultTracing implements TracingFunc
-// It fetch opentracing headers from the kafka message headers, then create a span using the opentracing.GlobalTracer()
+// It fetches opentracing headers from the kafka message headers, then creates a span using the opentracing.GlobalTracer()
 // usage: `listener, err = kafka.NewListener(brokers, appName, handlers, kafka.WithTracing(kafka.DefaultTracing))`
 func DefaultTracing(ctx context.Context, msg *sarama.ConsumerMessage) (opentracing.Span, context.Context) {
 	if ctx == nil {

--- a/options.go
+++ b/options.go
@@ -1,0 +1,39 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"github.com/Shopify/sarama"
+	"github.com/opentracing/opentracing-go"
+	"github.com/ricardo-ch/go-tracing"
+)
+
+//WithInstrumenting add a instance of Prometheus metrics
+func WithInstrumenting() ListenerOption {
+	return func(l *listener) {
+		l.instrumenting = NewConsumerMetricsService(l.groupID)
+	}
+}
+
+// ContextFunc is used to create tracing and/or propagate the tracing context from the each messages to the go context.
+type ContextFunc func(ctx context.Context) (opentracing.Span, context.Context)
+
+// WithTracing accept a ContextFunc to execute before each message
+func WithTracing(tracer ContextFunc) ListenerOption {
+	return func(l *listener) {
+		l.tracer = tracer
+	}
+}
+
+func DefaultTracing(ctx context.Context, msg *sarama.ConsumerMessage) (opentracing.Span, context.Context) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	carrier := make(map[string]string, len(msg.Headers))
+	for _, h := range msg.Headers {
+		carrier[string(h.Key)] = string(h.Value)
+	}
+	return tracing.ExtractFromCarrier(ctx, carrier, fmt.Sprintf("message from %s", msg.Topic),
+		&map[string]interface{}{"offset": msg.Offset, "partition": msg.Partition, "key": string(msg.Key)},
+	)
+}

--- a/options.go
+++ b/options.go
@@ -15,7 +15,7 @@ func WithInstrumenting() ListenerOption {
 	}
 }
 
-// TracingFunc is used to create tracing and/or propagate the tracing context from the each messages to the go context.
+// TracingFunc is used to create tracing and/or propagate the tracing context from each messages to the go context.
 type TracingFunc func(ctx context.Context, msg *sarama.ConsumerMessage) (opentracing.Span, context.Context)
 
 // WithTracing accept a TracingFunc to execute before each message

--- a/options.go
+++ b/options.go
@@ -18,7 +18,7 @@ func WithInstrumenting() ListenerOption {
 // TracingFunc is used to create tracing and/or propagate the tracing context from each messages to the go context.
 type TracingFunc func(ctx context.Context, msg *sarama.ConsumerMessage) (opentracing.Span, context.Context)
 
-// WithTracing accept a TracingFunc to execute before each message
+// WithTracing accepts a TracingFunc to execute before each message
 func WithTracing(tracer TracingFunc) ListenerOption {
 	return func(l *listener) {
 		l.tracer = tracer

--- a/options.go
+++ b/options.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ricardo-ch/go-tracing"
 )
 
-//WithInstrumenting add a instance of Prometheus metrics
+// WithInstrumenting adds an instance of Prometheus metrics
 func WithInstrumenting() ListenerOption {
 	return func(l *listener) {
 		l.instrumenting = NewConsumerMetricsService(l.groupID)

--- a/options.go
+++ b/options.go
@@ -16,7 +16,7 @@ func WithInstrumenting() ListenerOption {
 }
 
 // ContextFunc is used to create tracing and/or propagate the tracing context from the each messages to the go context.
-type ContextFunc func(ctx context.Context) (opentracing.Span, context.Context)
+type ContextFunc func(ctx context.Context, msg *sarama.ConsumerMessage) (opentracing.Span, context.Context)
 
 // WithTracing accept a ContextFunc to execute before each message
 func WithTracing(tracer ContextFunc) ListenerOption {

--- a/options.go
+++ b/options.go
@@ -25,7 +25,7 @@ func WithTracing(tracer TracingFunc) ListenerOption {
 	}
 }
 
-// DefaultTracing implement TracingFunc
+// DefaultTracing implements TracingFunc
 // It fetch opentracing headers from the kafka message headers, then create a span using the opentracing.GlobalTracer()
 // usage: `listener, err = kafka.NewListener(brokers, appName, handlers, kafka.WithTracing(kafka.DefaultTracing))`
 func DefaultTracing(ctx context.Context, msg *sarama.ConsumerMessage) (opentracing.Span, context.Context) {


### PR DESCRIPTION
When trying to implement the tracing using kafka headers as a medium, I figured that I could not build the context from the decode function.
The problem is the decode function does not return a context.
Also, the decode function is the only one that has access to the kafka headers.

I could have changed the signature of the decodeFunc interface, but I know we designed it this way to match go-kit library and I would rather not break any middleware we have built so far.

In this PR, I added a new option on the listener to handle tracing.
You can use any implementation that matches the `TracingFunc` interface, but it comes with a default implementation that might be totally enough for most use cases.

Even if we are using go-tracing here as a helper to extract the tracing headers, we are only using opentracing features. So this should be pretty robust to any actual tracing implementation that you want to use.