### PR TITLE
increase default offset retention to a month

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ All this strategy can be overridden through the following config variables:
 Configuration of consumer/producer is opinionated. It aim to resolve simply problems that have taken us by surprise in the past.
 For this reason:
 - the default partioner is based on murmur2 instead of the one sarama use by default
-- offset retention is set to 8 days
+- offset retention is set to 30 days
 - initial offset is oldest
 
 ## License

--- a/go-kafka.go
+++ b/go-kafka.go
@@ -51,7 +51,7 @@ func init() {
 	// Init config with default values
 	Config.Consumer.Return.Errors = true
 	Config.Consumer.Offsets.Initial = sarama.OffsetOldest
-	Config.Consumer.Offsets.Retention = 192 * time.Hour // 8 days to be above the default message retention time (7 days)
+	Config.Consumer.Offsets.Retention = 30 * 24 * time.Hour // 30 days, because we tend to increase the retention of a topic to a few weeks for practical purpose
 	Config.Producer.Timeout = 5 * time.Second
 	Config.Producer.Retry.Max = 3
 	Config.Producer.Return.Successes = true


### PR DESCRIPTION
This will help avoiding issue when team increase the retention of a topic to 2-3 weeks.
This tends to happen a lot because 1 week is way too short to investigate an issue or synchronise the work between 2 teams.