### PR TITLE
Add headers from message to the context that is passed to handler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   coveralls: coveralls/coveralls@1.0.6
 jobs:
-  build-1:
+  quality-gate:
     docker:
       - image: 'circleci/golang:1.17'
     steps:
@@ -16,13 +16,15 @@ jobs:
       - run:
           name: Test
           command: make test
-      - coveralls/upload:
-          parallel: false
-          token: ${COVERALLS_REPO_TOKEN}
-
+      - run:
+          name: install coveralls
+          command: go install github.com/mattn/goveralls@latest
+      - run:
+          name: code coverage
+          command: goveralls -service=circle-ci -ignore "mocks/*" -repotoken=$COVERALLS_REPO_TOKEN
 workflows:
   version: 2
   coveralls_workflow:
     jobs:
-      - build-1:
+      - quality-gate:
           context: dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2.1
+orbs:
+  coveralls: coveralls/coveralls@1.0.6
+jobs:
+  build-1:
+    docker:
+      - image: 'circleci/golang:1.17'
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: make install
+      - run:
+          name: Build
+          command: make build
+      - run:
+          name: Test
+          command: make test
+      - coveralls/upload:
+          parallel: false
+          token: ${COVERALLS_REPO_TOKEN}
+
+workflows:
+  version: 2
+  coveralls_workflow:
+    jobs:
+      - build-1:
+          context: dev

--- a/listener.go
+++ b/listener.go
@@ -175,6 +175,9 @@ func (l *listener) onNewMessage(msg *sarama.ConsumerMessage, session sarama.Cons
 	messageContext = context.WithValue(messageContext, contextkeyKey, msg.Key)
 	messageContext = context.WithValue(messageContext, contextOffsetKey, msg.Offset)
 	messageContext = context.WithValue(messageContext, contextTimestampKey, msg.Timestamp)
+	for _, h := range msg.Headers {
+		messageContext = context.WithValue(messageContext, listenerContextKey(h.Key), h.Value)
+	}
 
 	var span opentracing.Span
 	if l.tracer != nil {


### PR DESCRIPTION
- this pr adds kafka message headers to the context that is passed to the handler function, closes: https://app.asana.com/0/1201393603062033/1200576434617638
- Run code coverage on cricle-ci