### PR TITLE
Small error handling improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   quality-gate:
     docker:
-      - image: 'cimg/go:1.19'
+      - image: 'cimg/go:1.20'
     steps:
       - checkout
       - run:

--- a/client.go
+++ b/client.go
@@ -1,10 +1,10 @@
 package kafka
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/Shopify/sarama"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.19
 require (
 	github.com/Shopify/sarama v1.37.2
 	github.com/opentracing/opentracing-go v1.2.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/ricardo-ch/go-tracing v0.5.1
 	github.com/stretchr/testify v1.8.0
@@ -32,6 +31,7 @@ require (
 	github.com/klauspost/compress v1.15.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/listener_test.go
+++ b/listener_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"errors"
+
 	"github.com/Shopify/sarama"
-	"github.com/pkg/errors"
 	"github.com/ricardo-ch/go-kafka/v2/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -228,7 +229,7 @@ func Test_handleErrorMessage_OmittedError(t *testing.T) {
 	}).Once()
 	ErrorLogger = mockLogger
 
-	l.handleErrorMessage(context.Background(), errors.Wrap(ErrEventOmitted, omittedError.Error()), nil)
+	l.handleErrorMessage(context.Background(), fmt.Errorf("%w: %w", omittedError, ErrEventOmitted), nil)
 
 	assert.True(t, errorLogged)
 }
@@ -256,7 +257,7 @@ func Test_handleMessageWithRetry_UnretriableError(t *testing.T) {
 	handlerCalled := 0
 	handler := func(ctx context.Context, msg *sarama.ConsumerMessage) error {
 		handlerCalled++
-		return errors.Wrap(ErrEventUnretriable, err.Error())
+		return fmt.Errorf("%w: %w", err, ErrEventUnretriable)
 	}
 
 	l := listener{}


### PR DESCRIPTION
* Remove all references to the deprecated pkg/errors library
* Fix the error stacktrace logging
* Improve error comparison for ErrEventUnretriable and ErrEventOmitted
    * (this was made possible thanks [to this adaptation of our internal errors](https://github.com/ricardo-ch/go-utils/pull/226))
* Build using go 1.20 instead of 1.19 to allow the multiple `%w` syntax I'm using in the tests (no expected impact on the rest of the library)