### PR TITLE
Enable CodeQL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ workflows:
 executors:
   go-bullseye:
     docker:
-      - image: docker.io/golang:1.18-bullseye
+      - image: docker.io/golang:1.20-bullseye
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,31 @@
 version: 2.1
-jobs:
-  quality-gate:
-    docker:
-      - image: 'cimg/go:1.20'
-    steps:
-      - checkout
-      - run:
-          name: Install
-          command: make install
-      - run:
-          name: Build
-          command: make build
-      - run:
-          name: Test
-          command: make test
+
+orbs:
+  go: circleci/go@1.7.1
+  compliance: ricardo/compliance-orb@2
+  ric-orb: ricardo/ric-orb@7
+
 workflows:
   version: 2
-  quality-gate:
+
+  build-test:
     jobs:
-      - quality-gate:
+      - ric-orb/quality_gate_job:
+          name: 'quality-gate'
           context: dev
+          executor: go-bullseye
+
+      - ric-orb/codeql:
+          context: dev
+          executor: go-bullseye
+          language: go
+          requires:
+          - quality-gate
+
+executors:
+  go-bullseye:
+    docker:
+      - image: docker.io/golang:1.18-bullseye
+        auth:
+          username: $DOCKER_HUB_USERNAME
+          password: $DOCKER_HUB_PASSWORD


### PR DESCRIPTION
- Use ric-orb's codeQL step
- Use go-bullseye instead of go-buster
- Upgrade isopod to its latest version
- build & test using go 1.20