### PR TITLE
Fix the name of 2 consumer metrics

### DIFF
--- a/instrumenting.go
+++ b/instrumenting.go
@@ -41,7 +41,7 @@ func getPrometheusRecordConsumedInstrumentation() *prometheus.CounterVec {
 			prometheus.CounterOpts{
 				Namespace: "kafka",
 				Subsystem: "consumer",
-				Name:      "records_consumed_total",
+				Name:      "record_consumed_total",
 				Help:      "Number of records consumed",
 			}, consumerMetricLabels)
 		prometheus.MustRegister(consumerRecordConsumedCounter)
@@ -62,7 +62,7 @@ func getPrometheusRecordConsumedLatencyInstrumentation() *prometheus.HistogramVe
 			prometheus.HistogramOpts{
 				Namespace: "kafka",
 				Subsystem: "consumer",
-				Name:      "record_consumed_latency_seconds",
+				Name:      "record_latency_seconds",
 				Help:      "Total duration in milliseconds",
 			}, consumerMetricLabels)
 		prometheus.MustRegister(consumerRecordConsumedLatency)


### PR DESCRIPTION
2 small mistakes had found their way into the name of the exposed consumer metrics:
* `kafka_consumer_record_consumed_total` had a plural `records` instead of a singular one
* `kafka_consumer_record_latency_seconds` contained an additional `consumed`, as in the `consumed_total` metric.

Both are now aligned with the ADR's expected exposed names.
The README was already documenting these 2 metrics under the correct names so it did not require any changes.