### PR TITLE
remove compliance orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   go: circleci/go@1.7.1
-  compliance: ricardo/compliance-orb@2
   ric-orb: ricardo/ric-orb@7
 
 workflows:


### PR DESCRIPTION
# remove compliance orb  
We found better way to do compliance checks, so we are removing compliance orb and its usages.

This PR is fyi, no change in app is expected, we will self merge. 

See umbrella ticket https://github.com/ricardo-ch/compliance-orb/issues/22
