### PR TITLE
Add kafka_consumergroup_current_message_timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The following metrics are available:
 | kafka_consumer_record_latency_seconds | kafka_topic, consumer_group | Latency of consuming a message |
 | kafka_consumer_record_omitted_total | kafka_topic, consumer_group | Number of messages omitted |
 | kafka_consumer_record_error_total | kafka_topic, consumer_group | Number of errors when consuming a message |
+| kafka_consumergroup_current_message_timestamp| kafka_topic, consumer_group, partition, type | Timestamp of the current message being processed. Type can be either of `LogAppendTime` or `CreateTime`. |
 | kafka_producer_record_send_total | kafka_topic | Number of messages sent |
 | kafka_producer_dead_letter_created_total | kafka_topic | Number of messages sent to a dead letter topic |
 | kafka_producer_record_error_total | kafka_topic | Number of errors when sending a message |


### PR DESCRIPTION
Following [the Kafka ADR update](https://github.com/ricardo-ch/ricardo-architecture/pull/119) which introduces 2 new optional metrics, I'm adding a first one to go-kafka.
The second will follow but will have a slightly different approach as it will need to be incremented by the client directly.