### PR TITLE
Introduce infinite retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ This can be configured through the following properties:
 * `ConsumerMaxRetries`
 * `DurationBeforeRetry`
 
+If you want to achieve a blocking retry pattern (ie. continuously retrying until the event is successfully consumed), you can set `ConsumerMaxRetries` to `InfiniteRetries` (-1).
+
 If you want to **not** retry specific errors, you can wrap them in a `kafka.ErrNonRetriable` error before returning them, or return a `kafka.ErrNonRetriable` directly.
 ```go
 // This error will not be retried

--- a/go-kafka.go
+++ b/go-kafka.go
@@ -34,6 +34,10 @@ var ErrorLogger StdLogger = log.New(os.Stderr, "[Go-Kafka] ", log.LstdFlags)
 // By default 3 times.
 var ConsumerMaxRetries = 3
 
+// InfiniteRetries is a constant to define infinite retries.
+// It is used to set the ConsumerMaxRetries to a blocking retry process.
+const InfiniteRetries = -1
+
 // DurationBeforeRetry is the duration we wait between process retries.
 // By default 2 seconds.
 var DurationBeforeRetry = 2 * time.Second

--- a/listener.go
+++ b/listener.go
@@ -254,14 +254,17 @@ func (l *listener) handleMessageWithRetry(ctx context.Context, handler Handler, 
 	err = handler(ctx, msg)
 	if err != nil && shouldRetry(retries, err) {
 		time.Sleep(DurationBeforeRetry)
-		return l.handleMessageWithRetry(ctx, handler, msg, retries-1)
+		if retries != InfiniteRetries {
+			retries--
+		}
+		return l.handleMessageWithRetry(ctx, handler, msg, retries)
 	}
 
 	return err
 }
 
 func shouldRetry(retries int, err error) bool {
-	if retries <= 0 {
+	if retries == 0 {
 		return false
 	}
 


### PR DESCRIPTION
Introduce a full blocking retry option for the listener:
By setting `ConsumerMaxRetries = InfiniteRetries`, the listener will never run out of retry attempts, and will keep trying to process the next event.