### PR TITLE
Correct issue on infinite retry

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -343,6 +343,11 @@ func (l *listener) handleMessageWithRetry(ctx context.Context, handler Handler, 
 		}
 	}()
 
+	// Check if context is still valid
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	err = handler.Processor(ctx, msg)
 	if err != nil && shouldRetry(retries, err) {
 		time.Sleep(*handler.Config.DurationBeforeRetry)


### PR DESCRIPTION
When the retry policy was defined as infinite, the context was not verified. 
If the application received a signal to stop,  it could never stop. 