### PR TITLE
Propagate the consumergroup context into the handler

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -249,7 +249,9 @@ func (l *listener) onNewMessage(msg *sarama.ConsumerMessage, session sarama.Cons
 		l.handleErrorMessage(err, handler, msg)
 	}
 
-	session.MarkMessage(msg, "")
+	if !errors.Is(err, context.Canceled) {
+		session.MarkMessage(msg, "")
+	}
 }
 
 func (l *listener) handleErrorMessage(initialError error, handler Handler, msg *sarama.ConsumerMessage) {

--- a/listener.go
+++ b/listener.go
@@ -245,7 +245,7 @@ func (l *listener) onNewMessage(msg *sarama.ConsumerMessage, session sarama.Cons
 
 	err := l.handleMessageWithRetry(messageContext, handler, msg, *handler.Config.ConsumerMaxRetries)
 	if err != nil {
-		err = fmt.Errorf("processing failed after all possible attempts attempts: %w", err)
+		err = fmt.Errorf("processing failed: %w", err)
 		l.handleErrorMessage(err, handler, msg)
 	}
 

--- a/listener.go
+++ b/listener.go
@@ -222,7 +222,7 @@ func (l *listener) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 }
 
 func (l *listener) onNewMessage(msg *sarama.ConsumerMessage, session sarama.ConsumerGroupSession) {
-	messageContext := context.WithValue(context.Background(), contextTopicKey, msg.Topic)
+	messageContext := context.WithValue(session.Context(), contextTopicKey, msg.Topic)
 	messageContext = context.WithValue(messageContext, contextkeyKey, msg.Key)
 	messageContext = context.WithValue(messageContext, contextOffsetKey, msg.Offset)
 	messageContext = context.WithValue(messageContext, contextTimestampKey, msg.Timestamp)

--- a/listener_test.go
+++ b/listener_test.go
@@ -172,6 +172,7 @@ func Test_ConsumeClaim_Happy_Path(t *testing.T) {
 	consumerGroupClaim.On("Messages").Return((<-chan *sarama.ConsumerMessage)(msgChanel))
 
 	consumerGroupSession := &mocks.ConsumerGroupSession{}
+	consumerGroupSession.On("Context").Return(context.Background())
 	consumerGroupSession.On("MarkMessage", mock.Anything, mock.Anything).Return()
 
 	handlerCalled := false
@@ -215,6 +216,7 @@ func Test_ConsumeClaim_Message_Error_WithErrorTopic(t *testing.T) {
 	consumerGroupClaim.On("Messages").Return((<-chan *sarama.ConsumerMessage)(msgChanel))
 
 	consumerGroupSession := &mocks.ConsumerGroupSession{}
+	consumerGroupSession.On("Context").Return(context.Background())
 	consumerGroupSession.On("MarkMessage", mock.Anything, mock.Anything).Return()
 
 	producer := &mocks.MockProducer{}
@@ -268,6 +270,7 @@ func Test_ConsumeClaim_Message_Error_WithPanicTopic(t *testing.T) {
 	consumerGroupClaim.On("Messages").Return((<-chan *sarama.ConsumerMessage)(msgChanel))
 
 	consumerGroupSession := &mocks.ConsumerGroupSession{}
+	consumerGroupSession.On("Context").Return(context.Background())
 	consumerGroupSession.On("MarkMessage", mock.Anything, mock.Anything).Return()
 
 	producer := &mocks.MockProducer{}
@@ -322,6 +325,7 @@ func Test_ConsumeClaim_Message_Error_WithHandlerSpecificRetryTopic(t *testing.T)
 	consumerGroupClaim.On("Messages").Return((<-chan *sarama.ConsumerMessage)(msgChanel))
 
 	consumerGroupSession := &mocks.ConsumerGroupSession{}
+	consumerGroupSession.On("Context").Return(context.Background())
 	consumerGroupSession.On("MarkMessage", mock.Anything, mock.Anything).Return()
 
 	producer := &mocks.MockProducer{}
@@ -501,6 +505,7 @@ func Test_ConsumerClaim_HappyPath_WithTracing(t *testing.T) {
 	consumerGroupClaim.On("Messages").Return((<-chan *sarama.ConsumerMessage)(msgChanel))
 
 	consumerGroupSession := &mocks.ConsumerGroupSession{}
+	consumerGroupSession.On("Context").Return(context.Background())
 	consumerGroupSession.On("MarkMessage", mock.Anything, mock.Anything).Return()
 
 	handlerCalled := false


### PR DESCRIPTION
This will make sure that context cancellations also stop workers that never go back up to Sarama's codebase - ie. for "blocking retries" patterns.

Missing for now: unit tests (incoming)