### PR TITLE
Add exponential backoff possibility in case of retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ return kafka.ErrNonRetriable
 ```
  
 #### exponential backoff 
-You can activate it but setting `ExponentialBackoff` config variable as true. You can set this properties as global, you have to use the configuration per-topic.  This configuration is useful in case of infinite retry configuration.
-The exponential backoff algorithm is define like this.
+You can activate it by setting `ExponentialBackoff` config variable as true. You can set this properties as global, you have to use the configuration per-topic.  This configuration is useful in case of infinite retry configuration.
+The exponential backoff algorithm is defined like this.
 
 $`retryDuration  = durationBeforeRetry * 2^{retries}`$
 

--- a/README.md
+++ b/README.md
@@ -110,12 +110,13 @@ Depending on the Retry topic/Deadletter topic/Max retries configuration, the eve
 
 ### Blocking Retries
 
-By default, failed events consumptions will be retried 3 times (each attempt is separated by 2 seconds).
+By default, failed events consumptions will be retried 3 times (each attempt is separated by 2 seconds) with no exponential backoff.
 This can be globally configured through the following properties:
-* `ConsumerMaxRetries`
-* `DurationBeforeRetry`
+* `ConsumerMaxRetries` (int)
+* `DurationBeforeRetry` (duration)
+* `ExponentialBackoff` (boolean)
 
-These properties can also be configured on a per-topic basis by setting the `ConsumerMaxRetries` and `DurationBeforeRetry` properties on the handler.
+These properties can also be configured on a per-topic basis by setting the `ConsumerMaxRetries`, `DurationBeforeRetry` and `ExponentialBackoff` properties on the handler.
 
 If you want to achieve a blocking retry pattern (ie. continuously retrying until the event is successfully consumed), you can set `ConsumerMaxRetries` to `InfiniteRetries` (-1).
 
@@ -128,6 +129,12 @@ return errors.Wrap(kafka.ErrNonRetriable, err.Error())
 // This error will also not be retried
 return kafka.ErrNonRetriable
 ```
+ 
+#### exponential backoff 
+The exponential backoff algorithm is define like this. You can activate it but setting `ExponentialBackoff` config variable as true. This configuration is useful in case of infinite retry configuration
+
+$`retryDuration  = durationBeforeRetry * 2^{retries}`$
+
 
 ### Deadletter And Retry topics
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ By default, failed events consumptions will be retried 3 times (each attempt is 
 This can be globally configured through the following properties:
 * `ConsumerMaxRetries` (int)
 * `DurationBeforeRetry` (duration)
-* `ExponentialBackoff` (boolean)
 
 These properties can also be configured on a per-topic basis by setting the `ConsumerMaxRetries`, `DurationBeforeRetry` and `ExponentialBackoff` properties on the handler.
 
@@ -131,10 +130,10 @@ return kafka.ErrNonRetriable
 ```
  
 #### exponential backoff 
-The exponential backoff algorithm is define like this. You can activate it but setting `ExponentialBackoff` config variable as true. This configuration is useful in case of infinite retry configuration
+You can activate it but setting `ExponentialBackoff` config variable as true. You can set this properties as global, you have to use the configuration per-topic.  This configuration is useful in case of infinite retry configuration.
+The exponential backoff algorithm is define like this.
 
 $`retryDuration  = durationBeforeRetry * 2^{retries}`$
-
 
 ### Deadletter And Retry topics
 

--- a/example/handler.go
+++ b/example/handler.go
@@ -22,6 +22,7 @@ func makeUserHandler(s Service) kafka.Handler {
 		Config: kafka.HandlerConfig{
 			ConsumerMaxRetries:  kafka.Ptr(2),
 			DurationBeforeRetry: kafka.Ptr(5 * time.Second),
+			ExponentialBackoff:  true,
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -41,9 +41,9 @@ require (
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	golang.org/x/crypto v0.18.0 // indirect
-	golang.org/x/net v0.20.0 // indirect
-	golang.org/x/sys v0.16.0 // indirect
+	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
-golang.org/x/crypto v0.18.0 h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc=
-golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -114,8 +114,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.20.0 h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=
-golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
@@ -125,8 +125,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
-golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/listener.go
+++ b/listener.go
@@ -370,7 +370,7 @@ func (l *listener) handleMessageWithRetry(ctx context.Context, handler Handler, 
 	err = handler.Processor(ctx, msg)
 	if err != nil && shouldRetry(retries, err) {
 		if exponentialBackoff {
-			backoffDuration := calculateExponentialBackoffDuration(retries, handler.Config.DurationBeforeRetry)
+			backoffDuration := calculateExponentialBackoffDuration(retryNumber, handler.Config.DurationBeforeRetry)
 			Logger.Printf("exponential backoff enable we will retry in %s", backoffDuration)
 			time.Sleep(backoffDuration)
 		} else {

--- a/listener.go
+++ b/listener.go
@@ -371,7 +371,7 @@ func (l *listener) handleMessageWithRetry(ctx context.Context, handler Handler, 
 	if err != nil && shouldRetry(retries, err) {
 		if exponentialBackoff {
 			backoffDuration := calculateExponentialBackoffDuration(retryNumber, handler.Config.DurationBeforeRetry)
-			Logger.Printf("exponential backoff enable we will retry in %s", backoffDuration)
+			Logger.Printf("exponential backoff enabled: we will retry in %s", backoffDuration)
 			time.Sleep(backoffDuration)
 		} else {
 			time.Sleep(*handler.Config.DurationBeforeRetry)

--- a/listener_test.go
+++ b/listener_test.go
@@ -457,7 +457,28 @@ func Test_handleMessageWithRetry(t *testing.T) {
 	}
 
 	l := listener{}
-	l.handleMessageWithRetry(context.Background(), handler, nil, 3)
+	l.handleMessageWithRetry(context.Background(), handler, nil, 3, false)
+
+	assert.Equal(t, 4, handlerCalled)
+}
+
+func Test_handleMessageWithRetryWithBackoff(t *testing.T) {
+	// Reduce the retry interval to speed up the test
+	DurationBeforeRetry = 1 * time.Millisecond
+
+	err := errors.New("This error should be retried")
+	handlerCalled := 0
+	handlerProcessor := func(ctx context.Context, msg *sarama.ConsumerMessage) error {
+		handlerCalled++
+		return err
+	}
+	handler := Handler{
+		Processor: handlerProcessor,
+		Config:    testHandlerConfig,
+	}
+
+	l := listener{}
+	l.handleMessageWithRetry(context.Background(), handler, nil, 3, true)
 
 	assert.Equal(t, 4, handlerCalled)
 }
@@ -475,7 +496,25 @@ func Test_handleMessageWithRetry_UnretriableError(t *testing.T) {
 	}
 
 	l := listener{}
-	l.handleMessageWithRetry(context.Background(), handler, nil, 3)
+	l.handleMessageWithRetry(context.Background(), handler, nil, 3, false)
+
+	assert.Equal(t, 1, handlerCalled)
+}
+
+func Test_handleMessageWithRetry_UnretriableErrorWithBackoff(t *testing.T) {
+	err := errors.New("This error should not be retried")
+	handlerCalled := 0
+	handlerProcessor := func(ctx context.Context, msg *sarama.ConsumerMessage) error {
+		handlerCalled++
+		return fmt.Errorf("%w: %w", err, ErrEventUnretriable)
+	}
+	handler := Handler{
+		Processor: handlerProcessor,
+		Config:    testHandlerConfig,
+	}
+
+	l := listener{}
+	l.handleMessageWithRetry(context.Background(), handler, nil, 3, true)
 
 	assert.Equal(t, 1, handlerCalled)
 }
@@ -503,7 +542,35 @@ func Test_handleMessageWithRetry_InfiniteRetries(t *testing.T) {
 	}
 
 	l := listener{}
-	l.handleMessageWithRetry(context.Background(), handler, nil, InfiniteRetries)
+	l.handleMessageWithRetry(context.Background(), handler, nil, InfiniteRetries, false)
+
+	assert.Equal(t, 5, handlerCalled)
+
+}
+func Test_handleMessageWithRetry_InfiniteRetriesWithBackoff(t *testing.T) {
+	// Reduce the retry interval to speed up the test
+	DurationBeforeRetry = 1 * time.Millisecond
+
+	err := errors.New("This error should be retried")
+	handlerCalled := 0
+	handlerProcessor := func(ctx context.Context, msg *sarama.ConsumerMessage) error {
+		handlerCalled++
+
+		// We simulate an infinite retry by failing 5 times, and then succeeding,
+		// which is above the 3 retries normally expected
+		if handlerCalled < 5 {
+			return err
+		}
+		return nil
+	}
+
+	handler := Handler{
+		Processor: handlerProcessor,
+		Config:    testHandlerConfig,
+	}
+
+	l := listener{}
+	l.handleMessageWithRetry(context.Background(), handler, nil, InfiniteRetries, true)
 
 	assert.Equal(t, 5, handlerCalled)
 
@@ -534,7 +601,7 @@ func Test_handleMessageWithRetry_InfiniteRetriesWithContextCancel(t *testing.T) 
 	}
 
 	l := listener{}
-	l.handleMessageWithRetry(ctx, handler, nil, InfiniteRetries)
+	l.handleMessageWithRetry(ctx, handler, nil, InfiniteRetries, false)
 
 	assert.Equal(t, 5, handlerCalled)
 
@@ -632,4 +699,57 @@ func Test_Listen_ContextCanceled(t *testing.T) {
 
 	assert.Equal(t, context.Canceled, err)
 	consumerGroup.AssertExpectations(t)
+}
+
+func Test_calculateExponentialBackoffDuration(t *testing.T) {
+	tests := []struct {
+		name          string
+		retries       int
+		baseDuration  *time.Duration
+		expectedDelay time.Duration
+	}{
+		{
+			name:          "nil base duration",
+			retries:       3,
+			baseDuration:  nil,
+			expectedDelay: 0,
+		},
+		{
+			name:          "zero retries",
+			retries:       0,
+			baseDuration:  Ptr(1 * time.Second),
+			expectedDelay: 1 * time.Second,
+		},
+		{
+			name:          "one retry",
+			retries:       1,
+			baseDuration:  Ptr(1 * time.Second),
+			expectedDelay: 2 * time.Second,
+		},
+		{
+			name:          "two retries",
+			retries:       2,
+			baseDuration:  Ptr(1 * time.Second),
+			expectedDelay: 4 * time.Second,
+		},
+		{
+			name:          "three retries",
+			retries:       3,
+			baseDuration:  Ptr(1 * time.Second),
+			expectedDelay: 8 * time.Second,
+		},
+		{
+			name:          "three retries with different base duration",
+			retries:       3,
+			baseDuration:  Ptr(500 * time.Millisecond),
+			expectedDelay: 4 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delay := calculateExponentialBackoffDuration(tt.retries, tt.baseDuration)
+			assert.Equal(t, tt.expectedDelay, delay)
+		})
+	}
 }

--- a/listener_test.go
+++ b/listener_test.go
@@ -457,7 +457,7 @@ func Test_handleMessageWithRetry(t *testing.T) {
 	}
 
 	l := listener{}
-	l.handleMessageWithRetry(context.Background(), handler, nil, 3, false)
+	l.handleMessageWithRetry(context.Background(), handler, nil, 3, 0, false)
 
 	assert.Equal(t, 4, handlerCalled)
 }
@@ -478,7 +478,7 @@ func Test_handleMessageWithRetryWithBackoff(t *testing.T) {
 	}
 
 	l := listener{}
-	l.handleMessageWithRetry(context.Background(), handler, nil, 3, true)
+	l.handleMessageWithRetry(context.Background(), handler, nil, 3, 0, true)
 
 	assert.Equal(t, 4, handlerCalled)
 }
@@ -496,7 +496,7 @@ func Test_handleMessageWithRetry_UnretriableError(t *testing.T) {
 	}
 
 	l := listener{}
-	l.handleMessageWithRetry(context.Background(), handler, nil, 3, false)
+	l.handleMessageWithRetry(context.Background(), handler, nil, 3, 0, false)
 
 	assert.Equal(t, 1, handlerCalled)
 }
@@ -514,7 +514,7 @@ func Test_handleMessageWithRetry_UnretriableErrorWithBackoff(t *testing.T) {
 	}
 
 	l := listener{}
-	l.handleMessageWithRetry(context.Background(), handler, nil, 3, true)
+	l.handleMessageWithRetry(context.Background(), handler, nil, 3, 0, true)
 
 	assert.Equal(t, 1, handlerCalled)
 }
@@ -542,7 +542,7 @@ func Test_handleMessageWithRetry_InfiniteRetries(t *testing.T) {
 	}
 
 	l := listener{}
-	l.handleMessageWithRetry(context.Background(), handler, nil, InfiniteRetries, false)
+	l.handleMessageWithRetry(context.Background(), handler, nil, InfiniteRetries, 0, false)
 
 	assert.Equal(t, 5, handlerCalled)
 
@@ -570,7 +570,7 @@ func Test_handleMessageWithRetry_InfiniteRetriesWithBackoff(t *testing.T) {
 	}
 
 	l := listener{}
-	l.handleMessageWithRetry(context.Background(), handler, nil, InfiniteRetries, true)
+	l.handleMessageWithRetry(context.Background(), handler, nil, InfiniteRetries, 0, true)
 
 	assert.Equal(t, 5, handlerCalled)
 
@@ -601,7 +601,7 @@ func Test_handleMessageWithRetry_InfiniteRetriesWithContextCancel(t *testing.T) 
 	}
 
 	l := listener{}
-	l.handleMessageWithRetry(ctx, handler, nil, InfiniteRetries, false)
+	l.handleMessageWithRetry(ctx, handler, nil, InfiniteRetries, 0, false)
 
 	assert.Equal(t, 5, handlerCalled)
 


### PR DESCRIPTION
This feature could be useful in case of infinite retry.  In the case of listener issues, this avoids making too many requests.