### PR TITLE
Add ReadMe details on Retry/Dead-letter mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,13 @@ func MakeHandler(service Service) kafka.Handler {
     }
 ```
 
-... then any `kafka.ErrEventUnretriable` will end up in the dead-letter topic.
+... then any `kafka.ErrEventUnretriable` will end up in the dead-letter topic. It could also be a dedicated retry topic.
 
-`kafka.ErrEventOmitted` is still simply and purely omitted.
+Summary:
+
+`kafka.ErrEventUnretriable` is pushed to the following configured topic if any.
+
+`kafka.ErrEventOmitted` is always omitted, whatever your config is.
 
 ## Instrumenting
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Note that, if global `PushConsumerErrorsToRetryTopic` or `PushConsumerErrorsToDe
 In certain scenarios, you might want to omit some errors. For example, you might want to discard outdated events that are not relevant anymore.
 Such events would increase a separate, dedicated metric instead of the error one, and would not be retried.
 To do so, wrap the errors that should lead to omitted events in a ErrEventOmitted, or return a kafka.ErrEventOmitted directly.
+
 ```go
 // This error will be omitted
 err := errors.New("my error")
@@ -162,6 +163,26 @@ return errors.Wrap(kafka.ErrEventOmitted, err.Error())
 // This error will also be omitted
 return kafka.ErrEventOmitted
 ```
+
+### DeadLetter and ErrEventUnretriable
+
+If `PushConsumerErrorsToRetryTopic` is `true` and settled in the default config or is set directly by your handler this way:
+
+```go
+func MakeHandler(service Service) kafka.Handler {
+    return kafka.Handler{
+        Processor: func(ctx context.Context, msg *sarama.ConsumerMessage) error {
+        //...
+        },
+        Config: kafka.HandlerConfig{
+            DeadLetterTopic: config.App.KafkaTopicTransactionsDLQ,
+        },
+    }
+```
+
+... then any `kafka.ErrEventUnretriable` will end up in the dead-letter topic.
+
+`kafka.ErrEventOmitted` is still simply and purely omitted.
 
 ## Instrumenting
 

--- a/listener.go
+++ b/listener.go
@@ -247,7 +247,6 @@ func (l *listener) onNewMessage(msg *sarama.ConsumerMessage, session sarama.Cons
 
 	err := l.handleMessageWithRetry(messageContext, handler, msg, *handler.Config.ConsumerMaxRetries, 0, handler.Config.ExponentialBackoff)
 	if err != nil {
-		err = fmt.Errorf("processing failed: %w", err)
 		l.handleErrorMessage(err, handler, msg)
 	}
 


### PR DESCRIPTION
More readme details on how to use `ErrEventUnretriable` and `ErrEventOmitted`.
Clarify and document error-handling semantics so that kafka.ErrEventUnretriable is routed to the configured dead-letter topic, while kafka.ErrEventOmitted continues to be simply dropped (omitted) without retry or dead-letter routing.

Also removes standard library error wrapping that breaks our logger’s type detection. (preventing stack trace and source displays)